### PR TITLE
Modified code block in train/test part of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,17 @@
 - Train
 
 ```bash
-sh train.sh or python train.py --dataset Synapse --cfg configs/swin_tiny_patch4_window7_224_lite.yaml --root_path your DATA_DIR --max_epochs 150 --output_dir your OUT_DIR  --img_size 224 --base_lr 0.05 --batch_size 24
+sh train.sh 
+# or 
+python train.py --dataset Synapse --cfg configs/swin_tiny_patch4_window7_224_lite.yaml --root_path your DATA_DIR --max_epochs 150 --output_dir your OUT_DIR  --img_size 224 --base_lr 0.05 --batch_size 24
 ```
 
 - Test 
 
 ```bash
-sh test.sh or python test.py --dataset Synapse --cfg configs/swin_tiny_patch4_window7_224_lite.yaml --is_saveni --volume_path your DATA_DIR --output_dir your OUT_DIR --max_epoch 150 --base_lr 0.05 --img_size 224 --batch_size 24
+sh test.sh 
+# or 
+python test.py --dataset Synapse --cfg configs/swin_tiny_patch4_window7_224_lite.yaml --is_saveni --volume_path your DATA_DIR --output_dir your OUT_DIR --max_epoch 150 --base_lr 0.05 --img_size 224 --batch_size 24
 ```
 
 ## Reproducibility


### PR DESCRIPTION
Hi @HuCaoFighting

Thanks for your great work on medical image segmentation.

When I try to use your code, I directly copy the whole line of training command in README.md. And no matter how a change the parameters of this command, the behavior of the program is not changed. Then I found you place two commans of training in one line and combine the with `or`. This is very confusing. 

```shell
sh train.sh or python train.py --dataset Synapse --cfg configs/swin_tiny_patch4_window7_224_lite.yaml --root_path your DATA_DIR --max_epochs 150 --output_dir your OUT_DIR  --img_size 224 --base_lr 0.05 --batch_size 24
```

So I modified the commands above to different lines. Hope this would help others who use this code.